### PR TITLE
Do not omit size 1 x dimension if y is also size 1

### DIFF
--- a/nbs_viewer/models/plot/plotDataModel.py
+++ b/nbs_viewer/models/plot/plotDataModel.py
@@ -115,28 +115,6 @@ class PlotDataModel(QWidget):
         )
 
         xlist, ylist = self._run.get_plot_data(xkeys, ykeys, norm_keys, indices)
-        """
-        time = ttime.time()
-        xlist, y, xkeylist = self._run._run.get_plot_data(
-            [self._xkey], [self._ykey], norm_keys, indices
-        )
-        y = y[0]
-        xlist = xlist[0]
-        print_debug(
-            "PlotDataModel.get_plot_data",
-            f"got plot data in {ttime.time() - time} seconds",
-        )
-        t2 = ttime.time()
-        # Get dimension names from dimension analysis
-        dim_info = self._run._run.analyze_dimensions(self._ykey, [self._xkey])
-        self.dimension_names = dim_info["ordered_dims"]
-        print_debug(
-            "PlotDataModel.get_plot_data",
-            f"got dimension names in {ttime.time() - t2} seconds",
-        )
-        # Select x dimensions based on plot dimensions
-        x = xlist[-dimension:] if dimension else xlist
-        """
         return xlist, ylist
 
     def update_data_info(self, norm_keys=None, indices=None, dimension=None):

--- a/nbs_viewer/models/plot/runModel.py
+++ b/nbs_viewer/models/plot/runModel.py
@@ -99,8 +99,10 @@ class RunModel(QObject):
 
     def get_plot_data(self, xkeys, ykey, norm_keys=None, slice_info=None):
         xlist, xnames, extra = self._run.get_dimension_axes(ykey, xkeys, slice_info)
-        xlist = [x for x in xlist if x.size > 1]  # omit empty dimensions
         ylist = self._run.getData(ykey, slice_info)
+        # We want to omit "empty" dimensions that have size 1, but not if we only have one data point
+        if ylist.size > 1:
+            xlist = [x for x in xlist if x.size > 1]
         if norm_keys is not None:
             normlist = [
                 self._run.getData(norm_key, slice_info) for norm_key in norm_keys


### PR DESCRIPTION
Fixes #2 

Bug was created by code that attempts to eliminate "dummy" dimensions that have shape 1, which can be a problem in some data from Tiled, for instance where a camera image has shape KxMxN where K is the number of exposures, but only one exposure was taken.

However, if we only have one point (i.e, count(1) ), the x dimension was being eliminated. We now check if the y data has size 1, and if so, do not do the x-dimension elimination.