### PR TITLE
Better handling of placeholder info, and runs with errors

### DIFF
--- a/nbs_viewer/models/catalog/bluesky.py
+++ b/nbs_viewer/models/catalog/bluesky.py
@@ -5,9 +5,9 @@ from qtpy.QtCore import QObject
 from databroker.queries import TimeRange
 
 from .base import CatalogBase
-from .table import CatalogTableModel
 from ..data import BlueskyRun, NBSRun
 from .chunkCache import ChunkCache
+from nbs_viewer.utils import print_debug
 
 
 class BlueskyCatalog(CatalogBase):
@@ -96,12 +96,24 @@ class BlueskyCatalog(CatalogBase):
         Tuple[Any, RUN_WRAPPER]
             Key-value pairs where the value is wrapped in a RUN_WRAPPER.
         """
+        print_debug(
+            "BlueskyCatalog.items_slice",
+            f"Getting slice {slice_obj}",
+            category="DEBUG_RUNLIST",
+        )
         sliced_items = (
             self._catalog.items()[slice_obj] if slice_obj else self._catalog.items()
         )
         for key, value in sliced_items:
             # print(f"Wrapping run {key}")
-            yield key, self.wrap_run(value, key)
+            try:
+                yield key, self.wrap_run(value, key)
+            except Exception as ex:
+                print_debug(
+                    "BlueskyCatalog.items_slice",
+                    f"Error wrapping run {key}: {ex}",
+                    category="DEBUG_RUNLIST",
+                )
 
     def search(self, query: Dict) -> "BlueskyCatalog":
         """

--- a/nbs_viewer/models/data/bluesky.py
+++ b/nbs_viewer/models/data/bluesky.py
@@ -84,7 +84,7 @@ class BlueskyRun(CatalogRun):
             print(f"Warning: Could not initialize data for run {key}: {e}")
             self._available_keys = []
 
-    @time_function(category="DEBUG_CATALOG")
+    @time_function(category="DEBUG_RUN")
     def _check_data_access(self):
         """Check if run has accessible data."""
         try:

--- a/nbs_viewer/utils.py
+++ b/nbs_viewer/utils.py
@@ -4,6 +4,7 @@ DEBUG_VARIABLES = {
     "PRINT_DEBUG": False,
     "DEBUG_CATALOG": False,
     "DEBUG_PLOTS": True,
+    "DEBUG_RUNLIST": False,
     "cache": True,
     "dimension": False,
 }

--- a/nbs_viewer/views/catalog/base.py
+++ b/nbs_viewer/views/catalog/base.py
@@ -289,8 +289,6 @@ class LazyLoadingTableView(QTableView):
         if hasattr(source_model, "set_visible_rows"):
             source_model.set_visible_rows(first_visible, last_visible)
 
-        # print(f"Visible rows: {first_visible} to {last_visible}")
-
 
 class CatalogTableView(QWidget):
     """A widget for displaying and managing catalog data in a table view."""


### PR DESCRIPTION
This should fix #7 via better error-handling if a run doesn't have a primary error stream. But the main problem was likely that if you scroll too quickly, placeholder data is loaded without the real data request being placed in the queue.

We needed to check if the existing table data was really the LOADING_PLACEHOLDER, and if so, make sure to put the row back into the work queue.